### PR TITLE
Sub-specialization of status as exception classes

### DIFF
--- a/acsys/__init__.py
+++ b/acsys/__init__.py
@@ -148,7 +148,7 @@ _ackMap = {
 
 
 def _throw_bug(_):
-    raise status.AcnetRequestTimeOutQueuedAtDestination
+    raise status.AcnetRequestTimeOutQueuedAtDestination()
 
 
 def _decode_ack(buf):
@@ -378,8 +378,6 @@ receive a properly created one indirectly through
                 except status.AcnetReplyTaskDisconnected:
                     if self.protocol is not None:
                         self.protocol = None
-                    raise
-                except status.Status as sts:
                     raise
         else:
             raise AcnetReplyTaskDisconnected()
@@ -778,10 +776,8 @@ problems, this method will raise an ACSys Status code.
         try:
             await self.request_reply(f'ACNET@{node}', b'\x00\x00', timeout=250)
             return True
-        except status.AcnetRequestTimeOutQueuedAtDestination as exception:
+        except status.AcnetRequestTimeOutQueuedAtDestination:
             return False
-        except status.Status as exception:
-            raise exception
 
 
 async def _create_socket():

--- a/acsys/__init__.py
+++ b/acsys/__init__.py
@@ -115,7 +115,7 @@ import socket
 import struct
 import nest_asyncio
 import acsys.status as status
-from acsys.status import ACNET_DISCONNECTED
+from acsys.status import AcnetReplyTaskDisconnected
 
 # https://packaging.python.org/guides/single-sourcing-package-version/#single-sourcing-the-version
 try:
@@ -148,7 +148,7 @@ _ackMap = {
 
 
 def _throw_bug(_):
-    raise status.ACNET_REQTMO
+    raise status.AcnetRequestTimeOutQueuedAtDestination
 
 
 def _decode_ack(buf):
@@ -228,7 +228,7 @@ class _AcnetdProtocol(asyncio.Protocol):
                 replier = pkt[6] * 256 + pkt[7]
                 reqid = pkt[17] * 256 + pkt[16]
                 last = (pkt[2] & 1) == 0
-                sts = status.Status(sts)
+                sts = status.Status.create(sts)
 
                 if sts != status.ACNET_PEND:
 
@@ -270,7 +270,7 @@ class _AcnetdProtocol(asyncio.Protocol):
         # Loop through all active requests and send a message
         # indicating the request is done.
 
-        msg = (0, ACNET_DISCONNECTED, b'')
+        msg = (0, AcnetReplyTaskDisconnected(), b'')
         for _, func in self._rpy_map.items():
             func(msg, True)
         self._rpy_map = {}
@@ -292,7 +292,7 @@ class _AcnetdProtocol(asyncio.Protocol):
             self.transport.write(buf)
             return _decode_ack(await ack_fut)
 
-        raise ACNET_DISCONNECTED
+        raise AcnetReplyTaskDisconnected()
 
 # This class manages the connection between the client and acnetd. It
 # defines the public API.
@@ -375,13 +375,14 @@ receive a properly created one indirectly through
             while True:
                 try:
                     return await self.protocol.xact(buf)
-                except status.Status as sts:
-                    if sts == ACNET_DISCONNECTED \
-                            and (self.protocol is not None):
+                except status.AcnetReplyTaskDisconnected:
+                    if self.protocol is not None:
                         self.protocol = None
                     raise
+                except status.Status as sts:
+                    raise
         else:
-            raise ACNET_DISCONNECTED
+            raise AcnetReplyTaskDisconnected()
 
     # Used to tell acnetd to cancel a specific request ID. This method
     # doesn't return an error; if the request ID existed, it'll be
@@ -417,7 +418,7 @@ receive a properly created one indirectly through
         _log.debug('registering with ACSys')
         buf = struct.pack('>I2H3IH', 18, 1, 1, self._raw_handle, 0, 0, 0)
         res = await proto.xact(buf)
-        sts = status.Status(res[1])
+        sts = status.Status.create(res[1])
 
         # A good reply is a tuple with 4 elements.
 
@@ -442,7 +443,7 @@ receive a properly created one indirectly through
                 raise
         else:
             _log.error('*** unable to connect to ACSys')
-            raise ACNET_DISCONNECTED
+            raise AcnetReplyTaskDisconnected()
 
     async def get_name(self, addr):
         """Look-up node name.
@@ -454,7 +455,7 @@ address, `addr`.
         if isinstance(addr, int) and 0 <= addr <= 0x10000:
             buf = struct.pack('>I2H2IH', 14, 1, 12, self._raw_handle, 0, addr)
             res = await self._xact(buf)
-            sts = status.Status(res[1])
+            sts = status.Status.create(res[1])
 
             # A good reply is a tuple with 3 elements.
 
@@ -477,7 +478,7 @@ the ACSys node name, `name`.
             buf = struct.pack('>I2H3I', 16, 1, 11, self._raw_handle, 0,
                               Connection.__ator(name))
             res = await self._xact(buf)
-            sts = status.Status(res[1])
+            sts = status.Status.create(res[1])
 
             # A good reply is a tuple with 4 elements.
 
@@ -500,7 +501,7 @@ connection.
         """
         buf = struct.pack('>I2H2I', 12, 1, 13, self._raw_handle, 0)
         res = await self._xact(buf)
-        sts = status.Status(res[1])
+        sts = status.Status.create(res[1])
 
         # A good reply is a tuple with 4 elements.
 
@@ -588,7 +589,7 @@ into this efficient format.
                               self._raw_handle, 0, task, node, mult,
                               timeout) + message
             res = await self._xact(buf)
-            sts = status.Status(res[1])
+            sts = status.Status.create(res[1])
 
             # A good reply is a tuple with 3 elements. The last
             # element will be the request ID, which is what we return
@@ -777,10 +778,9 @@ problems, this method will raise an ACSys Status code.
         try:
             await self.request_reply(f'ACNET@{node}', b'\x00\x00', timeout=250)
             return True
+        except status.AcnetRequestTimeOutQueuedAtDestination as exception:
+            return False
         except status.Status as exception:
-            if exception == status.ACNET_REQTMO:
-                return False
-
             raise exception
 
 

--- a/acsys/dpm/__init__.py
+++ b/acsys/dpm/__init__.py
@@ -147,7 +147,7 @@ the result of a setting.
 
     def __init__(self, tag, status):
         self._tag = tag
-        self._status = acsys.status.Status(status)
+        self._status = acsys.status.Status.create(status)
 
     @property
     def tag(self):
@@ -232,7 +232,7 @@ for you as well as clean-up properly.
         try:
             return await asyncio.wait_for(self._transport, timeout=None)
         except asyncio.TimeoutError as exc:
-            raise acsys.status.ACNET_DISCONNECTED from exc
+            raise acsys.status.AcnetReplyTaskDisconnected() from exc
 
     # We use the state of the DPM object to initialize the state of
     # the connection. This means a new DPM object will do the minimum
@@ -360,7 +360,7 @@ for you as well as clean-up properly.
                             DigitalAlarm_reply,
                             BasicStatus_reply)):
             return ItemData(msg.ref_id, msg.cycle, msg.timestamp,
-                            acsys.status.Status(msg.status),
+                            acsys.status.Status.create(msg.status),
                             msg.__dict__, meta=self.meta.get(msg.ref_id, {}))
         if isinstance(msg, (Raw_reply,
                             ScalarArray_reply,
@@ -368,7 +368,7 @@ for you as well as clean-up properly.
                             TextArray_reply,
                             Text_reply)):
             return ItemData(msg.ref_id, msg.cycle, msg.timestamp,
-                            acsys.status.Status(msg.status),
+                            acsys.status.Status.create(msg.status),
                             msg.data, meta=self.meta.get(msg.ref_id, {}))
         if isinstance(msg, ApplySettings_reply):
             return [ItemStatus(reply.ref_id, reply.status)
@@ -386,7 +386,7 @@ for you as well as clean-up properly.
             return None
         if isinstance(msg, TimedScalarArray_reply):
             return ItemData(msg.ref_id, msg.cycle, msg.timestamp,
-                            acsys.status.Status(msg.status),
+                            acsys.status.Status.create(msg.status),
                             msg.data, meta=self.meta.get(msg.ref_id, {}),
                             micros=msg.micros)
         return msg

--- a/acsys/scaling/__init__.py
+++ b/acsys/scaling/__init__.py
@@ -18,12 +18,10 @@ async def find_service(con, node=None):
         node = await con.get_name(replier)
         _log.debug('found SCALE service at node %s', node)
         return node
-    except acsys.status.AcnetRequestTimeOutQueuedAtDestination:
-        raise acsys.status.AcnetNoSuchRequestOrReply()
+    except acsys.status.AcnetRequestTimeOutQueuedAtDestination as exception:
+        raise acsys.status.AcnetNoSuchRequestOrReply() from exception
     except acsys.status.AcnetUserGeneratedNetworkTimeout:
         return None
-    except acsys.status.Status:
-        raise
 
 
 async def convert_data(con, drf, data, node=None):

--- a/acsys/scaling/__init__.py
+++ b/acsys/scaling/__init__.py
@@ -18,13 +18,12 @@ async def find_service(con, node=None):
         node = await con.get_name(replier)
         _log.debug('found SCALE service at node %s', node)
         return node
-    except acsys.status.Status as exception:
-        if exception == acsys.status.ACNET_REQTMO:
-            raise acsys.status.ACNET_NO_SUCH
-        if exception != acsys.status.ACNET_UTIME:
-            raise
-
+    except acsys.status.AcnetRequestTimeOutQueuedAtDestination:
+        raise acsys.status.AcnetNoSuchRequestOrReply()
+    except acsys.status.AcnetUserGeneratedNetworkTimeout:
         return None
+    except acsys.status.Status:
+        raise
 
 
 async def convert_data(con, drf, data, node=None):
@@ -73,12 +72,12 @@ in `acsys.status.ACNET_UTIME` being raised.
     if node is None:
         node = await find_service(con)
         if node is None:
-            raise acsys.status.ACNET_NO_NODE
+            raise acsys.status.AcnetNoSuchLogicalNode()
 
     _, reply = await con.request_reply(f'SCALE@{node}', msg, timeout=1000,
                                        proto=acsys.scaling.scaling_protocol)
 
-    status = acsys.status.Status(reply.status)
+    status = acsys.status.Status.create(reply.status)
 
     if status.is_success:
         if hasattr(reply, 'raw'):

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -1,6 +1,7 @@
+from abc import abstractmethod, ABC
 from enum import IntEnum
 
-class Status:
+class Status(ABC):
     """An ACSys status type."""
     class Codes(IntEnum):
         """ACNET common status codes"""
@@ -79,10 +80,16 @@ class Status:
         ACNET_NO_HANDLE = 1 + 256 * -52
         """requested handle doesn't exist"""
 
-    def __init__(self, val):
-        """Creates a status value which is initialized with the supplied
-        value. The value must be in the range of signed, 16-bit
-        integers.
+    @abstractmethod
+    def __init__(self) -> None:
+        """
+        Use Status.create(val), or specific AcnetXXX() class instead.
+        """
+        pass
+
+    def _set_val(self, val):
+        """Set's supplied value, which must be in the range of signed, 16-bit
+        integers. 
         Do not use this method directly, use Status.create(val), or
         specific AcnetXXX() class instead.
         """
@@ -135,12 +142,16 @@ class Status:
         """
         # In case zero is given as a value / zero facility code
         if val == 0:
-            return Status(Status.Codes.ACNET_SUCCESS)
+            st = _SuccessStatus()
+            st._set_val(Status.Codes.ACNET_SUCCESS)
+            return st
         # Non-error codes
         elif val == Status.Codes.ACNET_SUCCESS or \
                 val == Status.Codes.ACNET_PEND or \
                 val == Status.Codes.ACNET_ENDMULT:
-            return Status(val)
+            st = _SuccessStatus()
+            st._set_val(val)
+            return st
         # Error codes build an exception
         elif val == Status.Codes.ACNET_RETRY:
             return AcnetRetryIOError()
@@ -213,6 +224,9 @@ class Status:
         else:
             raise ValueError(f"Invalid ACNET Status code: {val}")
 
+class _SuccessStatus(Status):
+    def __init__(self) -> None:
+        pass
 
 # Clases that specialize Status - based on code, that can be captured on different except clauses
 class AcnetException(Status, Exception):
@@ -222,205 +236,205 @@ class AcnetException(Status, Exception):
 class AcnetRetryIOError(AcnetException):
     """retryable I/O error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_RETRY)
+        self._set_val(Status.Codes.ACNET_RETRY)
         Exception.__init__(self)
 
 class AcnetNoLocalMemory(AcnetException):
     """no local memory available"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NOLCLMEM)
+        self._set_val(Status.Codes.ACNET_NOLCLMEM)
         Exception.__init__(self)
 
 class AcnetNoRemoteMemory(AcnetException):
     """no remote memory available"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NOREMMEM)
+        self._set_val(Status.Codes.ACNET_NOREMMEM)
         Exception.__init__(self)
 
 class AcnetReplyMessagePacketAssemblyError(AcnetException):
     """reply message packet assembly error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_RPLYPACK)
+        self._set_val(Status.Codes.ACNET_RPLYPACK)
         Exception.__init__(self)
 
 class AcnetRequestMessagePacketAssemblyError(AcnetException):
     """request message packet assembly error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_REQPACK)
+        self._set_val(Status.Codes.ACNET_REQPACK)
         Exception.__init__(self)
 
 class AcnetRequestTimeOutQueuedAtDestination(AcnetException):
     """request timeout with queued at destination"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_REQTMO)
+        self._set_val(Status.Codes.ACNET_REQTMO)
         Exception.__init__(self)
 
 class AcnetDestinationQueueFull(AcnetException):
     """request failed, destination queue full"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_QUEFULL)
+        self._set_val(Status.Codes.ACNET_QUEFULL)
         Exception.__init__(self)
 
 class AcnetDestinationBusy(AcnetException):
     """request failed, destination task busy"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_BUSY)
+        self._set_val(Status.Codes.ACNET_BUSY)
         Exception.__init__(self)
 
 class AcnetNotConnected(AcnetException):
     """not connected to the network"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NOT_CONNECTED)
+        self._set_val(Status.Codes.ACNET_NOT_CONNECTED)
         Exception.__init__(self)
 
 class AcnetMissingArguments(AcnetException):
     """missing arguments"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_ARG)
+        self._set_val(Status.Codes.ACNET_ARG)
         Exception.__init__(self)
 
 class AcnetInvalidMessageLengthOrBufferAddress(AcnetException):
     """invalid message length or buffer address"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_IVM)
+        self._set_val(Status.Codes.ACNET_IVM)
         Exception.__init__(self)
 
 class AcnetNoSuchRequestOrReply(AcnetException):
     """no such request or reply"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NO_SUCH)
+        self._set_val(Status.Codes.ACNET_NO_SUCH)
         Exception.__init__(self)
 
 class RequestToDestinationTaskRejected(AcnetException):
     """request to destination task was rejected"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_REQREJ)
+        self._set_val(Status.Codes.ACNET_REQREJ)
         Exception.__init__(self)
 
 class RequestedCancelled(AcnetException):
     """request has been cancelled"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_CANCELLED)
+        self._set_val(Status.Codes.ACNET_CANCELLED)
         Exception.__init__(self)
 
 class AcnetNameAlreadyInUse(AcnetException):
     """task name already in use"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NAME_IN_USE)
+        self._set_val(Status.Codes.ACNET_NAME_IN_USE)
         Exception.__init__(self)
 
 class AcnetNotConnectedAsRumTask(AcnetException):
     """not connected as a RUM task"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NCR)
+        self._set_val(Status.Codes.ACNET_NCR)
         Exception.__init__(self)
 
 class AcnetNoSuchLogicalNode(AcnetException):
     """no such logical node"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NO_NODE)
+        self._set_val(Status.Codes.ACNET_NO_NODE)
         Exception.__init__(self)
 
 class AcnetTruncatedRequest(AcnetException):
     """truncated request"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_TRUNC_REQUEST)
+        self._set_val(Status.Codes.ACNET_TRUNC_REQUEST)
         Exception.__init__(self)
 
 class AcnetTruncatedReply(AcnetException):
     """truncated reply"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_TRUNC_REPLY)
+        self._set_val(Status.Codes.ACNET_TRUNC_REPLY)
         Exception.__init__(self)
 
 class AcnetNoSuchDestinationTask(AcnetException):
     """no such destination task"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NO_TASK)
+        self._set_val(Status.Codes.ACNET_NO_TASK)
         Exception.__init__(self)
 
 class AcnetReplyTaskDisconnected(AcnetException):
     """replier task being disconnected"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_DISCONNECTED)
+        self._set_val(Status.Codes.ACNET_DISCONNECTED)
         Exception.__init__(self)
 
 class AcnetLevel2FunctionError(AcnetException):
     """ACNET level II function error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_LEVEL2)
+        self._set_val(Status.Codes.ACNET_LEVEL2)
         Exception.__init__(self)
 
 class AcnetHardIOError(AcnetException):
     """hard I/O error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_HARD_IO)
+        self._set_val(Status.Codes.ACNET_HARD_IO)
         Exception.__init__(self)
 
 class AcnetLogicalNodeDownOffline(AcnetException):
     """logical node down or offline"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NODE_DOWN)
+        self._set_val(Status.Codes.ACNET_NODE_DOWN)
         Exception.__init__(self)
 
 class AcnetSystemServiceError(AcnetException):
     """system service error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_SYS)
+        self._set_val(Status.Codes.ACNET_SYS)
         Exception.__init__(self)
 
 class AcnetUntranslatableError(AcnetException):
     """untranslatable error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NXE)
+        self._set_val(Status.Codes.ACNET_NXE)
         Exception.__init__(self)
 
 class AcnetNetworkInternalError(AcnetException):
     """network internal error"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_BUG)
+        self._set_val(Status.Codes.ACNET_BUG)
         Exception.__init__(self)
 
 class AcnetNE1_VMSExceededQuota(AcnetException):
     """VMS exceeded some quota or limit"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NE1)
+        self._set_val(Status.Codes.ACNET_NE1)
         Exception.__init__(self)
 
 class AcnetNE2_VMSNoAdressForRequestOrReply(AcnetException):
     """VMS no address for request/reply ID word"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NE2)
+        self._set_val(Status.Codes.ACNET_NE2)
         Exception.__init__(self)
 
 class AcnetNE3_VMSBufferInUse(AcnetException):
     """VMS buffer/control block vector in use or block already locked"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NE3)
+        self._set_val(Status.Codes.ACNET_NE3)
         Exception.__init__(self)
 
 class AcnetUserGeneratedNetworkTimeout(AcnetException):
     """user-generated network timeout"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_UTIME)
+        self._set_val(Status.Codes.ACNET_UTIME)
         Exception.__init__(self)
 
 class AcnetInvalidArgumentPassed(AcnetException):
     """invalid argument passed"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_INVARG)
+        self._set_val(Status.Codes.ACNET_INVARG)
         Exception.__init__(self)
 
 class AcnetMemoryAllocationFailed(AcnetException):
     """memory allocation failed"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_MEMFAIL)
+        self._set_val(Status.Codes.ACNET_MEMFAIL)
         Exception.__init__(self)
 
 class AcnetNoRequestHandle(AcnetException):
     """requested handle doesn't exist"""
     def __init__(self):
-        Status.__init__(self, Status.Codes.ACNET_NO_HANDLE)
+        self._set_val(Status.Codes.ACNET_NO_HANDLE)
         Exception.__init__(self)
 
 # Objects that represent an instance of each status, so they can be compared

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -1,13 +1,11 @@
 from enum import IntEnum
 
-class Status(Exception):
+class Status:
     """An ACSys status type."""
 
     class Codes(IntEnum):
         """ACNET common status codes"""
-        #ACNET_SUCCESS = 1 + 256 * 0
-        # TODO is this zero or 0x01?
-        ACNET_SUCCESS = 0
+        ACNET_SUCCESS = 1 + 256 * 0
         ACNET_PEND = 1 + 256 * 1
         ACNET_ENDMULT = 1 + 256 * 2
         ACNET_RETRY = 1 + 256 * -1
@@ -49,8 +47,8 @@ class Status(Exception):
         """Creates a status value which is initialized with the supplied
         value. The value must be in the range of signed, 16-bit
         integers.
+        Do not use this method directly, use Status.create(val) instead.
         """
-        super().__init__()
         if -0x8000 < val <= 0x7fff:
             self.value = val
         else:
@@ -94,11 +92,19 @@ class Status(Exception):
 
     @staticmethod
     def create(val):
-        # Clases that specialize Status - based on code, that can be captured as exceptions
-        if val == Status.Codes.ACNET_SUCCESS or \
+        """
+        Factory method to build ACNET Status codes. If given an error
+        code, it will build a raisable (AcnetException) object.
+        """
+        # In case zero is given as a value / zero facility code
+        if val == 0:
+            return Status(Status.Codes.ACNET_SUCCESS)
+        # Non-error codes
+        elif val == Status.Codes.ACNET_SUCCESS or \
                 val == Status.Codes.ACNET_PEND or \
                 val == Status.Codes.ACNET_ENDMULT:
             return Status(val)
+        # Error codes build an exception
         elif val == Status.Codes.ACNET_RETRY:
             return AcnetRetryIOError()
         elif val == Status.Codes.ACNET_NOLCLMEM:
@@ -172,142 +178,144 @@ class Status(Exception):
 
 
 # Clases that specialize Status - based on code, that can be captured on different except clauses
+class AcnetException(Status, Exception):
+    pass
 
-class AcnetRetryIOError(Status):
+class AcnetRetryIOError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_RETRY)
+        Status.__init__(self, Status.Codes.ACNET_RETRY)
 
-class AcnetNoLocalMemory(Status):
+class AcnetNoLocalMemory(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NOLCLMEM)
+        Status.__init__(self, Status.Codes.ACNET_NOLCLMEM)
 
-class AcnetNoRemoteMemory(Status):
+class AcnetNoRemoteMemory(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NOREMMEM)
+        Status.__init__(self, Status.Codes.ACNET_NOREMMEM)
 
-class AcnetReplyMessagePacketAssemblyError(Status):
+class AcnetReplyMessagePacketAssemblyError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_RPLYPACK)
+        Status.__init__(self, Status.Codes.ACNET_RPLYPACK)
 
-class AcnetRequestMessagePacketAssemblyError(Status):
+class AcnetRequestMessagePacketAssemblyError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_REQPACK)
+        Status.__init__(self, Status.Codes.ACNET_REQPACK)
 
-class AcnetRequestTimeOutQueuedAtDestination(Status):
+class AcnetRequestTimeOutQueuedAtDestination(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_REQTMO)
+        Status.__init__(self, Status.Codes.ACNET_REQTMO)
 
-class AcnetDestinationQueueFull(Status):
+class AcnetDestinationQueueFull(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_QUEFULL)
+        Status.__init__(self, Status.Codes.ACNET_QUEFULL)
 
-class AcnetDestinationBusy(Status):
+class AcnetDestinationBusy(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_BUSY)
+        Status.__init__(self, Status.Codes.ACNET_BUSY)
 
-class AcnetNotConnected(Status):
+class AcnetNotConnected(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NOT_CONNECTED)
+        Status.__init__(self, Status.Codes.ACNET_NOT_CONNECTED)
 
-class AcnetMissingArguments(Status):
+class AcnetMissingArguments(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_ARG)
+        Status.__init__(self, Status.Codes.ACNET_ARG)
 
-class AcnetInvalidMessageLengthOrBufferAddress(Status):
+class AcnetInvalidMessageLengthOrBufferAddress(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_IVM)
+        Status.__init__(self, Status.Codes.ACNET_IVM)
 
-class AcnetNoSuchRequestOrReply(Status):
+class AcnetNoSuchRequestOrReply(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NO_SUCH)
+        Status.__init__(self, Status.Codes.ACNET_NO_SUCH)
 
-class RequestToDestinationTaskRejected(Status):
+class RequestToDestinationTaskRejected(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_REQREJ)
+        Status.__init__(self, Status.Codes.ACNET_REQREJ)
 
-class RequestedCancelled(Status):
+class RequestedCancelled(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_CANCELLED)
+        Status.__init__(self, Status.Codes.ACNET_CANCELLED)
 
-class AcnetNameAlreadyInUse(Status):
+class AcnetNameAlreadyInUse(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NAME_IN_USE)
+        Status.__init__(self, Status.Codes.ACNET_NAME_IN_USE)
 
-class AcnetNotConnectedAsRumTask(Status):
+class AcnetNotConnectedAsRumTask(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NCR)
+        Status.__init__(self, Status.Codes.ACNET_NCR)
 
-class AcnetNoSuchLogicalNode(Status):
+class AcnetNoSuchLogicalNode(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NO_NODE)
+        Status.__init__(self, Status.Codes.ACNET_NO_NODE)
 
-class AcnetTruncatedRequest(Status):
+class AcnetTruncatedRequest(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_TRUNC_REQUEST)
+        Status.__init__(self, Status.Codes.ACNET_TRUNC_REQUEST)
 
-class AcnetTruncatedReply(Status):
+class AcnetTruncatedReply(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_TRUNC_REPLY)
+        Status.__init__(self, Status.Codes.ACNET_TRUNC_REPLY)
 
-class AcnetNoSuchDestinationTask(Status):
+class AcnetNoSuchDestinationTask(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NO_TASK)
+        Status.__init__(self, Status.Codes.ACNET_NO_TASK)
 
-class AcnetReplyTaskDisconnected(Status):
+class AcnetReplyTaskDisconnected(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_DISCONNECTED)
+        Status.__init__(self, Status.Codes.ACNET_DISCONNECTED)
 
-class AcnetLevel2FunctionError(Status):
+class AcnetLevel2FunctionError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_LEVEL2)
+        Status.__init__(self, Status.Codes.ACNET_LEVEL2)
 
-class AcnetHardIOError(Status):
+class AcnetHardIOError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_HARD_IO)
+        Status.__init__(self, Status.Codes.ACNET_HARD_IO)
 
-class AcnetLogicalNodeDownOffline(Status):
+class AcnetLogicalNodeDownOffline(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NODE_DOWN)
+        Status.__init__(self, Status.Codes.ACNET_NODE_DOWN)
 
-class AcnetSystemServiceError(Status):
+class AcnetSystemServiceError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_SYS)
+        Status.__init__(self, Status.Codes.ACNET_SYS)
 
-class AcnetUntranslatableError(Status):
+class AcnetUntranslatableError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NXE)
+        Status.__init__(self, Status.Codes.ACNET_NXE)
 
-class AcnetNetworkInternalError(Status):
+class AcnetNetworkInternalError(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_BUG)
+        Status.__init__(self, Status.Codes.ACNET_BUG)
 
-class AcnetNE1_VMSExceededQuota(Status):
+class AcnetNE1_VMSExceededQuota(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NE1)
+        Status.__init__(self, Status.Codes.ACNET_NE1)
 
-class AcnetNE2_VMSNoAdressForRequestOrReply(Status):
+class AcnetNE2_VMSNoAdressForRequestOrReply(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NE2)
+        Status.__init__(self, Status.Codes.ACNET_NE2)
 
-class AcnetNE3_VMSBufferInUse(Status):
+class AcnetNE3_VMSBufferInUse(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NE3)
+        Status.__init__(self, Status.Codes.ACNET_NE3)
 
-class AcnetUserGeneratedNetworkTimeout(Status):
+class AcnetUserGeneratedNetworkTimeout(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_UTIME)
+        Status.__init__(self, Status.Codes.ACNET_UTIME)
 
-class AcnetInvalidArgumentPassed(Status):
+class AcnetInvalidArgumentPassed(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_INVARG)
+        Status.__init__(self, Status.Codes.ACNET_INVARG)
 
-class AcnetMemoryAllocationFailed(Status):
+class AcnetMemoryAllocationFailed(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_MEMFAIL)
+        Status.__init__(self, Status.Codes.ACNET_MEMFAIL)
 
-class AcnetNoRequestHandle(Status):
+class AcnetNoRequestHandle(AcnetException):
     def __init__(self):
-        super().__init__(Status.Codes.ACNET_NO_HANDLE)
+        Status.__init__(self, Status.Codes.ACNET_NO_HANDLE)
 
 
 # Objects that represent an instance of each status, so they can be compared

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -2,52 +2,89 @@ from enum import IntEnum
 
 class Status:
     """An ACSys status type."""
-
     class Codes(IntEnum):
         """ACNET common status codes"""
-        ACNET_SUCCESS = 1 + 256 * 0
+        ACNET_SUCCESS = 1 + 256 * 0 
+        """ACNET success code"""
         ACNET_PEND = 1 + 256 * 1
+        """operation is pending"""
         ACNET_ENDMULT = 1 + 256 * 2
+        """end multiple replies (on final reply)"""
         ACNET_RETRY = 1 + 256 * -1
+        """retryable I/O error"""
         ACNET_NOLCLMEM = 1 + 256 * -2
+        """no local memory available"""
         ACNET_NOREMMEM = 1 + 256 * -3
+        """no remote memory available"""
         ACNET_RPLYPACK = 1 + 256 * -4
+        """reply message packet assembly error"""
         ACNET_REQPACK = 1 + 256 * -5
+        """request message packet assembly error"""
         ACNET_REQTMO = 1 + 256 * -6
+        """request timeout with queued at destination"""
         ACNET_QUEFULL = 1 + 256 * -7
+        """request failed, destination queue full"""
         ACNET_BUSY = 1 + 256 * -8
+        """request failed, destination task busy"""
         ACNET_NOT_CONNECTED = 1 + 256 * -21
+        """not connected to the network"""
         ACNET_ARG = 1 + 256 * -22
+        """missing arguments"""
         ACNET_IVM = 1 + 256 * -23
+        """invalid message length or buffer address"""
         ACNET_NO_SUCH = 1 + 256 * -24
+        """no such request or reply"""
         ACNET_REQREJ = 1 + 256 * -25
+        """request to destination task was rejected"""
         ACNET_CANCELLED = 1 + 256 * -26
+        """request has been cancelled"""
         ACNET_NAME_IN_USE = 1 + 256 * -27
+        """task name already in use"""
         ACNET_NCR = 1 + 256 * -28
+        """not connected as a RUM task"""
         ACNET_NO_NODE = 1 + 256 * -30
+        """no such logical node"""
         ACNET_TRUNC_REQUEST = 1 + 256 * -31
+        """truncated request"""
         ACNET_TRUNC_REPLY = 1 + 256 * -32
+        """truncated reply"""
         ACNET_NO_TASK = 1 + 256 * -33
+        """no such destination task"""
         ACNET_DISCONNECTED = 1 + 256 * -34
+        """replier task being disconnected"""
         ACNET_LEVEL2 = 1 + 256 * -35
+        """ACNET level II function error"""
         ACNET_HARD_IO = 1 + 256 * -41
+        """hard I/O error"""
         ACNET_NODE_DOWN = 1 + 256 * -42
+        """logical node down or offline"""
         ACNET_SYS = 1 + 256 * -43
+        """system service error"""
         ACNET_NXE = 1 + 256 * -44
+        """untranslatable error"""
         ACNET_BUG = 1 + 256 * -45
+        """network internal error"""
         ACNET_NE1 = 1 + 256 * -46
+        """VMS exceeded some quota or limit"""
         ACNET_NE2 = 1 + 256 * -47
+        """VMS no address for request/reply ID word"""
         ACNET_NE3 = 1 + 256 * -48
+        """VMS buffer/control block vector in use or block already locked"""
         ACNET_UTIME = 1 + 256 * -49
+        """user-generated network timeout"""
         ACNET_INVARG = 1 + 256 * -50
+        """invalid argument passed"""
         ACNET_MEMFAIL = 1 + 256 * -51
+        """memory allocation failed"""
         ACNET_NO_HANDLE = 1 + 256 * -52
+        """requested handle doesn't exist"""
 
     def __init__(self, val):
         """Creates a status value which is initialized with the supplied
         value. The value must be in the range of signed, 16-bit
         integers.
-        Do not use this method directly, use Status.create(val) instead.
+        Do not use this method directly, use Status.create(val), or
+        specific AcnetXXX() class instead.
         """
         if -0x8000 < val <= 0x7fff:
             self.value = val
@@ -179,174 +216,209 @@ class Status:
 
 # Clases that specialize Status - based on code, that can be captured on different except clauses
 class AcnetException(Status, Exception):
+    """Use this to capture error statuses"""
     pass
 
 class AcnetRetryIOError(AcnetException):
+    """retryable I/O error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_RETRY)
         Exception.__init__(self)
 
 class AcnetNoLocalMemory(AcnetException):
+    """no local memory available"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOLCLMEM)
         Exception.__init__(self)
 
 class AcnetNoRemoteMemory(AcnetException):
+    """no remote memory available"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOREMMEM)
         Exception.__init__(self)
 
 class AcnetReplyMessagePacketAssemblyError(AcnetException):
+    """reply message packet assembly error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_RPLYPACK)
         Exception.__init__(self)
 
 class AcnetRequestMessagePacketAssemblyError(AcnetException):
+    """request message packet assembly error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQPACK)
         Exception.__init__(self)
 
 class AcnetRequestTimeOutQueuedAtDestination(AcnetException):
+    """request timeout with queued at destination"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQTMO)
         Exception.__init__(self)
 
 class AcnetDestinationQueueFull(AcnetException):
+    """request failed, destination queue full"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_QUEFULL)
         Exception.__init__(self)
 
 class AcnetDestinationBusy(AcnetException):
+    """request failed, destination task busy"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_BUSY)
         Exception.__init__(self)
 
 class AcnetNotConnected(AcnetException):
+    """not connected to the network"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOT_CONNECTED)
         Exception.__init__(self)
 
 class AcnetMissingArguments(AcnetException):
+    """missing arguments"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_ARG)
         Exception.__init__(self)
 
 class AcnetInvalidMessageLengthOrBufferAddress(AcnetException):
+    """invalid message length or buffer address"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_IVM)
         Exception.__init__(self)
 
 class AcnetNoSuchRequestOrReply(AcnetException):
+    """no such request or reply"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_SUCH)
         Exception.__init__(self)
 
 class RequestToDestinationTaskRejected(AcnetException):
+    """request to destination task was rejected"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQREJ)
         Exception.__init__(self)
 
 class RequestedCancelled(AcnetException):
+    """request has been cancelled"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_CANCELLED)
         Exception.__init__(self)
 
 class AcnetNameAlreadyInUse(AcnetException):
+    """task name already in use"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NAME_IN_USE)
         Exception.__init__(self)
 
 class AcnetNotConnectedAsRumTask(AcnetException):
+    """not connected as a RUM task"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NCR)
         Exception.__init__(self)
 
 class AcnetNoSuchLogicalNode(AcnetException):
+    """no such logical node"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_NODE)
         Exception.__init__(self)
 
 class AcnetTruncatedRequest(AcnetException):
+    """truncated request"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_TRUNC_REQUEST)
         Exception.__init__(self)
 
 class AcnetTruncatedReply(AcnetException):
+    """truncated reply"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_TRUNC_REPLY)
         Exception.__init__(self)
 
 class AcnetNoSuchDestinationTask(AcnetException):
+    """no such destination task"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_TASK)
         Exception.__init__(self)
 
 class AcnetReplyTaskDisconnected(AcnetException):
+    """replier task being disconnected"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_DISCONNECTED)
         Exception.__init__(self)
 
 class AcnetLevel2FunctionError(AcnetException):
+    """ACNET level II function error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_LEVEL2)
         Exception.__init__(self)
 
 class AcnetHardIOError(AcnetException):
+    """hard I/O error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_HARD_IO)
         Exception.__init__(self)
 
 class AcnetLogicalNodeDownOffline(AcnetException):
+    """logical node down or offline"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NODE_DOWN)
         Exception.__init__(self)
 
 class AcnetSystemServiceError(AcnetException):
+    """system service error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_SYS)
         Exception.__init__(self)
 
 class AcnetUntranslatableError(AcnetException):
+    """untranslatable error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NXE)
         Exception.__init__(self)
 
 class AcnetNetworkInternalError(AcnetException):
+    """network internal error"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_BUG)
         Exception.__init__(self)
 
 class AcnetNE1_VMSExceededQuota(AcnetException):
+    """VMS exceeded some quota or limit"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE1)
         Exception.__init__(self)
 
 class AcnetNE2_VMSNoAdressForRequestOrReply(AcnetException):
+    """VMS no address for request/reply ID word"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE2)
         Exception.__init__(self)
 
 class AcnetNE3_VMSBufferInUse(AcnetException):
+    """VMS buffer/control block vector in use or block already locked"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE3)
         Exception.__init__(self)
 
 class AcnetUserGeneratedNetworkTimeout(AcnetException):
+    """user-generated network timeout"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_UTIME)
         Exception.__init__(self)
 
 class AcnetInvalidArgumentPassed(AcnetException):
+    """invalid argument passed"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_INVARG)
         Exception.__init__(self)
 
 class AcnetMemoryAllocationFailed(AcnetException):
+    """memory allocation failed"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_MEMFAIL)
         Exception.__init__(self)
 
 class AcnetNoRequestHandle(AcnetException):
+    """requested handle doesn't exist"""
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_HANDLE)
         Exception.__init__(self)
@@ -357,38 +429,73 @@ ACNET_SUCCESS = Status.create(Status.Codes.ACNET_SUCCESS)
 ACNET_PEND = Status.create(Status.Codes.ACNET_PEND)
 ACNET_ENDMULT = Status.create(Status.Codes.ACNET_ENDMULT)
 
-# TODO deprecate this globals
-ACNET_RETRY = Status.create(Status.Codes.ACNET_RETRY)
+# TODO these globals can be used but are redundant.
+# Should be deleted on subsequent versions
+ACNET_RETRY = Status.create(Status.Codes.ACNET_RETRY) 
+""" @deprecated: Use AcnetRetryIOError() instead """
 ACNET_NOLCLMEM = Status.create(Status.Codes.ACNET_NOLCLMEM)
+""" @deprecated: Use AcnetNoLocalMemory() instead """
 ACNET_NOREMMEM = Status.create(Status.Codes.ACNET_NOREMMEM)
+""" @deprecated: Use AcnetNoRemoteMemory() instead """
 ACNET_RPLYPACK = Status.create(Status.Codes.ACNET_RPLYPACK)
+""" @deprecated: Use AcnetReplyMessagePacketAssemblyError() instead """
 ACNET_REQPACK = Status.create(Status.Codes.ACNET_REQPACK)
+""" @deprecated: Use AcnetRequestMessagePacketAssemblyError() instead """
 ACNET_REQTMO = Status.create(Status.Codes.ACNET_REQTMO)
+""" @deprecated: Use AcnetRequestTimeOutQueuedAtDestination() instead """
 ACNET_QUEFULL = Status.create(Status.Codes.ACNET_QUEFULL)
+""" @deprecated: Use AcnetDestinationQueueFull() instead """
 ACNET_BUSY = Status.create(Status.Codes.ACNET_BUSY)
+""" @deprecated: Use AcnetDestinationBusy() instead """
 ACNET_NOT_CONNECTED = Status.create(Status.Codes.ACNET_NOT_CONNECTED)
+""" @deprecated: Use AcnetNotConnected() instead """
 ACNET_ARG = Status.create(Status.Codes.ACNET_ARG)
+""" @deprecated: Use AcnetMissingArguments() instead """
 ACNET_IVM = Status.create(Status.Codes.ACNET_IVM)
+""" @deprecated: Use AcnetInvalidMessageLengthOrBufferAddress() instead """
 ACNET_NO_SUCH = Status.create(Status.Codes.ACNET_NO_SUCH)
+""" @deprecated: Use AcnetNoSuchRequestOrReply() instead """
 ACNET_REQREJ = Status.create(Status.Codes.ACNET_REQREJ)
+""" @deprecated: Use RequestToDestinationTaskRejected() instead """
 ACNET_CANCELLED = Status.create(Status.Codes.ACNET_CANCELLED)
+""" @deprecated: Use RequestedCancelled() instead """
 ACNET_NAME_IN_USE = Status.create(Status.Codes.ACNET_NAME_IN_USE)
+""" @deprecated: Use AcnetNameAlreadyInUse() instead """
 ACNET_NCR = Status.create(Status.Codes.ACNET_NCR)
+""" @deprecated: Use AcnetNotConnectedAsRumTask() instead """
 ACNET_NO_NODE = Status.create(Status.Codes.ACNET_NO_NODE)
+""" @deprecated: Use AcnetNoSuchLogicalNode() instead """
 ACNET_TRUNC_REQUEST = Status.create(Status.Codes.ACNET_TRUNC_REQUEST)
+""" @deprecated: Use AcnetTruncatedRequest() instead """
 ACNET_TRUNC_REPLY = Status.create(Status.Codes.ACNET_TRUNC_REPLY)
+""" @deprecated: Use AcnetTruncatedReply() instead """
 ACNET_NO_TASK = Status.create(Status.Codes.ACNET_NO_TASK)
+""" @deprecated: Use AcnetNoSuchDestinationTask() instead """
 ACNET_DISCONNECTED = Status.create(Status.Codes.ACNET_DISCONNECTED)
+""" @deprecated: Use AcnetReplyTaskDisconnected() instead """
 ACNET_LEVEL2 = Status.create(Status.Codes.ACNET_LEVEL2)
+""" @deprecated: Use AcnetLevel2FunctionError() instead """
 ACNET_HARD_IO = Status.create(Status.Codes.ACNET_HARD_IO)
+""" @deprecated: Use AcnetHardIOError() instead """
 ACNET_NODE_DOWN = Status.create(Status.Codes.ACNET_NODE_DOWN)
+""" @deprecated: Use AcnetLogicalNodeDownOffline() instead """
 ACNET_SYS = Status.create(Status.Codes.ACNET_SYS)
+""" @deprecated: Use AcnetSystemServiceError() instead """
 ACNET_NXE = Status.create(Status.Codes.ACNET_NXE)
+""" @deprecated: Use AcnetUntranslatableError() instead """
 ACNET_BUG = Status.create(Status.Codes.ACNET_BUG)
+""" @deprecated: Use AcnetNetworkInternalError() instead """
 ACNET_NE1 = Status.create(Status.Codes.ACNET_NE1)
+""" @deprecated: Use AcnetNE1_VMSExceededQuota() instead """
 ACNET_NE2 = Status.create(Status.Codes.ACNET_NE2)
+""" @deprecated: Use AcnetNE2_VMSNoAdressForRequestOrReply() instead """
 ACNET_NE3 = Status.create(Status.Codes.ACNET_NE3)
+""" @deprecated: Use AcnetNE3_VMSBufferInUse() instead """
 ACNET_UTIME = Status.create(Status.Codes.ACNET_UTIME)
+""" @deprecated: Use AcnetUserGeneratedNetworkTimeout() instead """
 ACNET_INVARG = Status.create(Status.Codes.ACNET_INVARG)
+""" @deprecated: Use AcnetInvalidArgumentPassed() instead """
 ACNET_MEMFAIL = Status.create(Status.Codes.ACNET_MEMFAIL)
+""" @deprecated: Use AcnetMemoryAllocationFailed() instead """
 ACNET_NO_HANDLE = Status.create(Status.Codes.ACNET_NO_HANDLE)
+""" @deprecated: Use AcnetNoRequestHandle() instead """

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -1,5 +1,49 @@
+from enum import IntEnum
+
 class Status(Exception):
     """An ACSys status type."""
+
+    class Codes(IntEnum):
+        """ACNET common status codes"""
+        # ACNET_SUCCESS = 1 + 256 * 0
+        # TODO is this zero or 0x01?
+        ACNET_SUCCESS = 0
+        ACNET_PEND = 1 + 256 * 1
+        ACNET_ENDMULT = 1 + 256 * 2
+        ACNET_RETRY = 1 + 256 * -1
+        ACNET_NOLCLMEM = 1 + 256 * -2
+        ACNET_NOREMMEM = 1 + 256 * -3
+        ACNET_RPLYPACK = 1 + 256 * -4
+        ACNET_REQPACK = 1 + 256 * -5
+        ACNET_REQTMO = 1 + 256 * -6
+        ACNET_QUEFULL = 1 + 256 * -7
+        ACNET_BUSY = 1 + 256 * -8
+        ACNET_NOT_CONNECTED = 1 + 256 * -21
+        ACNET_ARG = 1 + 256 * -22
+        ACNET_IVM = 1 + 256 * -23
+        ACNET_NO_SUCH = 1 + 256 * -24
+        ACNET_REQREJ = 1 + 256 * -25
+        ACNET_CANCELLED = 1 + 256 * -26
+        ACNET_NAME_IN_USE = 1 + 256 * -27
+        ACNET_NCR = 1 + 256 * -28
+        ACNET_NO_NODE = 1 + 256 * -30
+        ACNET_TRUNC_REQUEST = 1 + 256 * -31
+        ACNET_TRUNC_REPLY = 1 + 256 * -32
+        ACNET_NO_TASK = 1 + 256 * -33
+        ACNET_DISCONNECTED = 1 + 256 * -34
+        ACNET_LEVEL2 = 1 + 256 * -35
+        ACNET_HARD_IO = 1 + 256 * -41
+        ACNET_NODE_DOWN = 1 + 256 * -42
+        ACNET_SYS = 1 + 256 * -43
+        ACNET_NXE = 1 + 256 * -44
+        ACNET_BUG = 1 + 256 * -45
+        ACNET_NE1 = 1 + 256 * -46
+        ACNET_NE2 = 1 + 256 * -47
+        ACNET_NE3 = 1 + 256 * -48
+        ACNET_UTIME = 1 + 256 * -49
+        ACNET_INVARG = 1 + 256 * -50
+        ACNET_MEMFAIL = 1 + 256 * -51
+        ACNET_NO_HANDLE = 1 + 256 * -52
 
     def __init__(self, val):
         """Creates a status value which is initialized with the supplied
@@ -48,44 +92,262 @@ class Status(Exception):
     def __str__(self):
         return f'[{self.facility} {self.err_code}]'
 
-# This section defines common ACNET status codes.
+    @staticmethod
+    def create(val):
+        # Clases that specialize Status - based on code, that can be captured as exceptions
+        if val == Status.Codes.ACNET_SUCCESS or \
+                val == Status.Codes.ACNET_PEND or \
+                val == Status.Codes.ACNET_ENDMULT:
+            return Status(val)
+        elif val == Status.Codes.ACNET_RETRY:
+            return AcnetRetryIOError()
+        elif val == Status.Codes.ACNET_NOLCLMEM:
+            return AcnetNoLocalMemory()
+        elif val == Status.Codes.ACNET_NOREMMEM:
+            return AcnetNoRemoteMemory()
+        elif val == Status.Codes.ACNET_RPLYPACK:
+            return AcnetReplyMessagePacketAssemblyError()
+        elif val == Status.Codes.ACNET_REQPACK:
+            return AcnetRequestMessagePacketAssemblyError()
+        elif val == Status.Codes.ACNET_REQTMO:
+            return AcnetRequestTimeOutQueuedAtDestination()
+        elif val == Status.Codes.ACNET_QUEFULL:
+            return AcnetDestinationQueueFull()
+        elif val == Status.Codes.ACNET_BUSY:
+            return AcnetDestinationBusy()
+        elif val == Status.Codes.ACNET_NOT_CONNECTED:
+            return AcnetNotConnected()
+        elif val == Status.Codes.ACNET_ARG:
+            return AcnetMissingArguments()
+        elif val == Status.Codes.ACNET_IVM:
+            return AcnetInvalidMessageLengthOrBufferAddress()
+        elif val == Status.Codes.ACNET_NO_SUCH:
+            return AcnetNoSuchRequestOrReply()
+        elif val == Status.Codes.ACNET_REQREJ:
+            return RequestToDestinationTaskRejected()
+        elif val == Status.Codes.ACNET_CANCELLED:
+            return RequestedCancelled()
+        elif val == Status.Codes.ACNET_NAME_IN_USE:
+            return AcnetNameAlreadyInUse()
+        elif val == Status.Codes.ACNET_NCR:
+            return AcnetNotConnectedAsRumTask()
+        elif val == Status.Codes.ACNET_NO_NODE:
+            return AcnetNoSuchLogicalNode()
+        elif val == Status.Codes.ACNET_TRUNC_REQUEST:
+            return AcnetTruncatedRequest()
+        elif val == Status.Codes.ACNET_TRUNC_REPLY:
+            return AcnetTruncatedReply()
+        elif val == Status.Codes.ACNET_NO_TASK:
+            return AcnetNoSuchDestinationTask()
+        elif val == Status.Codes.ACNET_DISCONNECTED:
+            return AcnetReplyTaskDisconnected()
+        elif val == Status.Codes.ACNET_LEVEL2:
+            return AcnetLevel2FunctionError()
+        elif val == Status.Codes.ACNET_HARD_IO:
+            return AcnetHardIOError()
+        elif val == Status.Codes.ACNET_NODE_DOWN:
+            return AcnetLogicalNodeDownOffline()
+        elif val == Status.Codes.ACNET_SYS:
+            return AcnetSystemServiceError()
+        elif val == Status.Codes.ACNET_NXE:
+            return AcnetUntranslatableError()
+        elif val == Status.Codes.ACNET_BUG:
+            return AcnetNetworkInternalError()
+        elif val == Status.Codes.ACNET_NE1:
+            return AcnetNE1_VMSExceededQuota()
+        elif val == Status.Codes.ACNET_NE2:
+            return AcnetNE2_VMSNoAdressForRequestOrReply()
+        elif val == Status.Codes.ACNET_NE3:
+            return AcnetNE3_VMSBufferInUse()
+        elif val == Status.Codes.ACNET_UTIME:
+            return AcnetUserGeneratedNetworkTimeout()
+        elif val == Status.Codes.ACNET_INVARG:
+            return AcnetInvalidArgumentPassed()
+        elif val == Status.Codes.ACNET_MEMFAIL:
+            return AcnetMemoryAllocationFailed()
+        elif val == Status.Codes.ACNET_NO_HANDLE:
+            return AcnetNoRequestHandle()
+        else:
+            raise ValueError(f"Invalid ACNET Status code: {val}")
 
 
-ACNET_SUCCESS = Status(1 + 256 * 0)
-ACNET_PEND = Status(1 + 256 * 1)
-ACNET_ENDMULT = Status(1 + 256 * 2)
+# Clases that specialize Status - based on code, that can be captured on different except clauses
 
-ACNET_RETRY = Status(1 + 256 * -1)
-ACNET_NOLCLMEM = Status(1 + 256 * -2)
-ACNET_NOREMMEM = Status(1 + 256 * -3)
-ACNET_RPLYPACK = Status(1 + 256 * -4)
-ACNET_REQPACK = Status(1 + 256 * -5)
-ACNET_REQTMO = Status(1 + 256 * -6)
-ACNET_QUEFULL = Status(1 + 256 * -7)
-ACNET_BUSY = Status(1 + 256 * -8)
-ACNET_NOT_CONNECTED = Status(1 + 256 * -21)
-ACNET_ARG = Status(1 + 256 * -22)
-ACNET_IVM = Status(1 + 256 * -23)
-ACNET_NO_SUCH = Status(1 + 256 * -24)
-ACNET_REQREJ = Status(1 + 256 * -25)
-ACNET_CANCELLED = Status(1 + 256 * -26)
-ACNET_NAME_IN_USE = Status(1 + 256 * -27)
-ACNET_NCR = Status(1 + 256 * -28)
-ACNET_NO_NODE = Status(1 + 256 * -30)
-ACNET_TRUNC_REQUEST = Status(1 + 256 * -31)
-ACNET_TRUNC_REPLY = Status(1 + 256 * -32)
-ACNET_NO_TASK = Status(1 + 256 * -33)
-ACNET_DISCONNECTED = Status(1 + 256 * -34)
-ACNET_LEVEL2 = Status(1 + 256 * -35)
-ACNET_HARD_IO = Status(1 + 256 * -41)
-ACNET_NODE_DOWN = Status(1 + 256 * -42)
-ACNET_SYS = Status(1 + 256 * -43)
-ACNET_NXE = Status(1 + 256 * -44)
-ACNET_BUG = Status(1 + 256 * -45)
-ACNET_NE1 = Status(1 + 256 * -46)
-ACNET_NE2 = Status(1 + 256 * -47)
-ACNET_NE3 = Status(1 + 256 * -48)
-ACNET_UTIME = Status(1 + 256 * -49)
-ACNET_INVARG = Status(1 + 256 * -50)
-ACNET_MEMFAIL = Status(1 + 256 * -51)
-ACNET_NO_HANDLE = Status(1 + 256 * -52)
+class AcnetRetryIOError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_RETRY)
+
+class AcnetNoLocalMemory(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NOLCLMEM)
+
+class AcnetNoRemoteMemory(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NOREMMEM)
+
+class AcnetReplyMessagePacketAssemblyError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_RPLYPACK)
+
+class AcnetRequestMessagePacketAssemblyError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_REQPACK)
+
+class AcnetRequestTimeOutQueuedAtDestination(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_REQTMO)
+
+class AcnetDestinationQueueFull(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_QUEFULL)
+
+class AcnetDestinationBusy(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_BUSY)
+
+class AcnetNotConnected(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NOT_CONNECTED)
+
+class AcnetMissingArguments(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_ARG)
+
+class AcnetInvalidMessageLengthOrBufferAddress(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_IVM)
+
+class AcnetNoSuchRequestOrReply(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NO_SUCH)
+
+class RequestToDestinationTaskRejected(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_REQREJ)
+
+class RequestedCancelled(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_CANCELLED)
+
+class AcnetNameAlreadyInUse(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NAME_IN_USE)
+
+class AcnetNotConnectedAsRumTask(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NCR)
+
+class AcnetNoSuchLogicalNode(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NO_NODE)
+
+class AcnetTruncatedRequest(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_TRUNC_REQUEST)
+
+class AcnetTruncatedReply(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_TRUNC_REPLY)
+
+class AcnetNoSuchDestinationTask(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NO_TASK)
+
+class AcnetReplyTaskDisconnected(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_DISCONNECTED)
+
+class AcnetLevel2FunctionError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_LEVEL2)
+
+class AcnetHardIOError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_HARD_IO)
+
+class AcnetLogicalNodeDownOffline(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NODE_DOWN)
+
+class AcnetSystemServiceError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_SYS)
+
+class AcnetUntranslatableError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NXE)
+
+class AcnetNetworkInternalError(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_BUG)
+
+class AcnetNE1_VMSExceededQuota(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NE1)
+
+class AcnetNE2_VMSNoAdressForRequestOrReply(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NE2)
+
+class AcnetNE3_VMSBufferInUse(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NE3)
+
+class AcnetUserGeneratedNetworkTimeout(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_UTIME)
+
+class AcnetInvalidArgumentPassed(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_INVARG)
+
+class AcnetMemoryAllocationFailed(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_MEMFAIL)
+
+class AcnetNoRequestHandle(Status):
+    def __init__(self):
+        super().__init__(Status.Codes.ACNET_NO_HANDLE)
+
+
+# Objects that represent an instance of each status, so they can be compared
+# inside an except clause.
+ACNET_SUCCESS = Status.create(Status.Codes.ACNET_SUCCESS)
+ACNET_PEND = Status.create(Status.Codes.ACNET_PEND)
+ACNET_ENDMULT = Status.create(Status.Codes.ACNET_ENDMULT)
+
+# TODO deprecate this globals
+ACNET_RETRY = Status.create(Status.Codes.ACNET_RETRY)
+ACNET_NOLCLMEM = Status.create(Status.Codes.ACNET_NOLCLMEM)
+ACNET_NOREMMEM = Status.create(Status.Codes.ACNET_NOREMMEM)
+ACNET_RPLYPACK = Status.create(Status.Codes.ACNET_RPLYPACK)
+ACNET_REQPACK = Status.create(Status.Codes.ACNET_REQPACK)
+ACNET_REQTMO = Status.create(Status.Codes.ACNET_REQTMO)
+ACNET_QUEFULL = Status.create(Status.Codes.ACNET_QUEFULL)
+ACNET_BUSY = Status.create(Status.Codes.ACNET_BUSY)
+ACNET_NOT_CONNECTED = Status.create(Status.Codes.ACNET_NOT_CONNECTED)
+ACNET_ARG = Status.create(Status.Codes.ACNET_ARG)
+ACNET_IVM = Status.create(Status.Codes.ACNET_IVM)
+ACNET_NO_SUCH = Status.create(Status.Codes.ACNET_NO_SUCH)
+ACNET_REQREJ = Status.create(Status.Codes.ACNET_REQREJ)
+ACNET_CANCELLED = Status.create(Status.Codes.ACNET_CANCELLED)
+ACNET_NAME_IN_USE = Status.create(Status.Codes.ACNET_NAME_IN_USE)
+ACNET_NCR = Status.create(Status.Codes.ACNET_NCR)
+ACNET_NO_NODE = Status.create(Status.Codes.ACNET_NO_NODE)
+ACNET_TRUNC_REQUEST = Status.create(Status.Codes.ACNET_TRUNC_REQUEST)
+ACNET_TRUNC_REPLY = Status.create(Status.Codes.ACNET_TRUNC_REPLY)
+ACNET_NO_TASK = Status.create(Status.Codes.ACNET_NO_TASK)
+ACNET_DISCONNECTED = Status.create(Status.Codes.ACNET_DISCONNECTED)
+ACNET_LEVEL2 = Status.create(Status.Codes.ACNET_LEVEL2)
+ACNET_HARD_IO = Status.create(Status.Codes.ACNET_HARD_IO)
+ACNET_NODE_DOWN = Status.create(Status.Codes.ACNET_NODE_DOWN)
+ACNET_SYS = Status.create(Status.Codes.ACNET_SYS)
+ACNET_NXE = Status.create(Status.Codes.ACNET_NXE)
+ACNET_BUG = Status.create(Status.Codes.ACNET_BUG)
+ACNET_NE1 = Status.create(Status.Codes.ACNET_NE1)
+ACNET_NE2 = Status.create(Status.Codes.ACNET_NE2)
+ACNET_NE3 = Status.create(Status.Codes.ACNET_NE3)
+ACNET_UTIME = Status.create(Status.Codes.ACNET_UTIME)
+ACNET_INVARG = Status.create(Status.Codes.ACNET_INVARG)
+ACNET_MEMFAIL = Status.create(Status.Codes.ACNET_MEMFAIL)
+ACNET_NO_HANDLE = Status.create(Status.Codes.ACNET_NO_HANDLE)

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -184,139 +184,172 @@ class AcnetException(Status, Exception):
 class AcnetRetryIOError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_RETRY)
+        Exception.__init__(self)
 
 class AcnetNoLocalMemory(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOLCLMEM)
+        Exception.__init__(self)
 
 class AcnetNoRemoteMemory(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOREMMEM)
+        Exception.__init__(self)
 
 class AcnetReplyMessagePacketAssemblyError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_RPLYPACK)
+        Exception.__init__(self)
 
 class AcnetRequestMessagePacketAssemblyError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQPACK)
+        Exception.__init__(self)
 
 class AcnetRequestTimeOutQueuedAtDestination(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQTMO)
+        Exception.__init__(self)
 
 class AcnetDestinationQueueFull(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_QUEFULL)
+        Exception.__init__(self)
 
 class AcnetDestinationBusy(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_BUSY)
+        Exception.__init__(self)
 
 class AcnetNotConnected(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NOT_CONNECTED)
+        Exception.__init__(self)
 
 class AcnetMissingArguments(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_ARG)
+        Exception.__init__(self)
 
 class AcnetInvalidMessageLengthOrBufferAddress(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_IVM)
+        Exception.__init__(self)
 
 class AcnetNoSuchRequestOrReply(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_SUCH)
+        Exception.__init__(self)
 
 class RequestToDestinationTaskRejected(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_REQREJ)
+        Exception.__init__(self)
 
 class RequestedCancelled(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_CANCELLED)
+        Exception.__init__(self)
 
 class AcnetNameAlreadyInUse(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NAME_IN_USE)
+        Exception.__init__(self)
 
 class AcnetNotConnectedAsRumTask(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NCR)
+        Exception.__init__(self)
 
 class AcnetNoSuchLogicalNode(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_NODE)
+        Exception.__init__(self)
 
 class AcnetTruncatedRequest(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_TRUNC_REQUEST)
+        Exception.__init__(self)
 
 class AcnetTruncatedReply(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_TRUNC_REPLY)
+        Exception.__init__(self)
 
 class AcnetNoSuchDestinationTask(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_TASK)
+        Exception.__init__(self)
 
 class AcnetReplyTaskDisconnected(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_DISCONNECTED)
+        Exception.__init__(self)
 
 class AcnetLevel2FunctionError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_LEVEL2)
+        Exception.__init__(self)
 
 class AcnetHardIOError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_HARD_IO)
+        Exception.__init__(self)
 
 class AcnetLogicalNodeDownOffline(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NODE_DOWN)
+        Exception.__init__(self)
 
 class AcnetSystemServiceError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_SYS)
+        Exception.__init__(self)
 
 class AcnetUntranslatableError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NXE)
+        Exception.__init__(self)
 
 class AcnetNetworkInternalError(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_BUG)
+        Exception.__init__(self)
 
 class AcnetNE1_VMSExceededQuota(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE1)
+        Exception.__init__(self)
 
 class AcnetNE2_VMSNoAdressForRequestOrReply(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE2)
+        Exception.__init__(self)
 
 class AcnetNE3_VMSBufferInUse(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NE3)
+        Exception.__init__(self)
 
 class AcnetUserGeneratedNetworkTimeout(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_UTIME)
+        Exception.__init__(self)
 
 class AcnetInvalidArgumentPassed(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_INVARG)
+        Exception.__init__(self)
 
 class AcnetMemoryAllocationFailed(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_MEMFAIL)
+        Exception.__init__(self)
 
 class AcnetNoRequestHandle(AcnetException):
     def __init__(self):
         Status.__init__(self, Status.Codes.ACNET_NO_HANDLE)
-
+        Exception.__init__(self)
 
 # Objects that represent an instance of each status, so they can be compared
 # inside an except clause.

--- a/acsys/status.py
+++ b/acsys/status.py
@@ -5,7 +5,7 @@ class Status(Exception):
 
     class Codes(IntEnum):
         """ACNET common status codes"""
-        # ACNET_SUCCESS = 1 + 256 * 0
+        #ACNET_SUCCESS = 1 + 256 * 0
         # TODO is this zero or 0x01?
         ACNET_SUCCESS = 0
         ACNET_PEND = 1 + 256 * 1

--- a/acsys/sync/__init__.py
+++ b/acsys/sync/__init__.py
@@ -95,8 +95,6 @@ no nodes are found, an empty list is returned.
             result.append(await con.get_name(replier))
     except acsys.status.AcnetUserGeneratedNetworkTimeout:
         return result
-    except acsys.status.Status as exception:
-        raise
     
 
 
@@ -152,6 +150,6 @@ occur.
                         yield ClockEvent(stamp, event.clock.event, event.clock.number)
         except acsys.status.AcnetReplyTaskDisconnected:
             raise
-        except acsys.status.Status as exception:
-            _log.warning('lost connection with SYNC service')
+        except acsys.status.AcnetException as exception:
+            _log.warning(f'lost connection with SYNC service: {exception!r}')
             await asyncio.sleep(0.5)

--- a/acsys/sync/__init__.py
+++ b/acsys/sync/__init__.py
@@ -76,8 +76,6 @@ async def find_service(con, clock=Clock_Tclk, node=None):
         return await con.get_name(replier)
     except acsys.status.AcnetUserGeneratedNetworkTimeout:
         return None
-    except acsys.status.Status:
-        raise
 
 
 async def get_available(con, clock=Clock_Tclk):

--- a/acsys/sync/__init__.py
+++ b/acsys/sync/__init__.py
@@ -74,11 +74,10 @@ async def find_service(con, clock=Clock_Tclk, node=None):
         replier, _ = await con.request_reply(task, msg, timeout=150,
                                              proto=acsys.sync.syncd_protocol)
         return await con.get_name(replier)
-    except acsys.status.Status as exception:
-        if exception != acsys.status.ACNET_UTIME:
-            raise
-
+    except acsys.status.AcnetUserGeneratedNetworkTimeout:
         return None
+    except acsys.status.Status:
+        raise
 
 
 async def get_available(con, clock=Clock_Tclk):
@@ -96,10 +95,11 @@ no nodes are found, an empty list is returned.
     try:
         async for replier, _ in gen:
             result.append(await con.get_name(replier))
+    except acsys.status.AcnetUserGeneratedNetworkTimeout:
+        return result
     except acsys.status.Status as exception:
-        if exception != acsys.status.ACNET_UTIME:
-            raise
-    return result
+        raise
+    
 
 
 async def get_events(con, ev_str, sync_node=None, clock=Clock_Tclk):
@@ -131,7 +131,7 @@ occur.
         if sync_node is None:
             node = await find_service(con, clock=clock, node=sync_node)
             if node is None:
-                raise acsys.status.ACNET_NO_NODE
+                raise acsys.status.AcnetNoSuchLogicalNode()
         else:
             node = sync_node
 
@@ -152,8 +152,8 @@ occur.
                                          event.state.value)
                     else:
                         yield ClockEvent(stamp, event.clock.event, event.clock.number)
+        except acsys.status.AcnetReplyTaskDisconnected:
+            raise
         except acsys.status.Status as exception:
-            if exception == acsys.status.ACNET_DISCONNECTED:
-                raise
             _log.warning('lost connection with SYNC service')
             await asyncio.sleep(0.5)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="acsys",
-    version="1.0.0rc6",
+    version="1.0.0rc7",
     author="Rich Neswold",
     author_email="neswold@fnal.gov",
     description="ACSys Client library",

--- a/tests/status.py
+++ b/tests/status.py
@@ -1,0 +1,12 @@
+from acsys.status import *
+
+st = AcnetRetryIOError()
+print(f"{st!r}")
+
+try:
+    print("Raising error")
+    raise st
+except AcnetReplyTaskDisconnected as ex:
+    print(f"Captured exception: {ex!r}")
+except Status as st2:
+    print(f"Captured any status: {st2!r}")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,28 +1,33 @@
-from acsys.status import *
+import acsys.status
 
-
-try:
-    print("Raising error")
-    raise AcnetRetryIOError()
-except AcnetReplyTaskDisconnected as ex:
-    print(f"Captured specific exception: {ex!r}")
-except AcnetException as ex:
-    print(f"Captured general exception: {ex!r}")
-
-try:
-    raise Status.create(1+256*-6)
-except AcnetRequestTimeOutQueuedAtDestination as ex:
-    print(f"Captured specific exception: {ex!r}")
-except AcnetException as ex:
-    print(f"Captured general exception: {ex!r}")
-
-
-try:
+if __name__ == '__main__':
     try:
-        raise AcnetRetryIOError()
-    except AcnetException as ex:
-        raise AcnetReplyTaskDisconnected() from ex
-except Exception as ex2:
-    print("Exception captured!")
-    print(f"Captured general exception: {ex2!r}")
-    raise
+        print("Raising error")
+        raise acsys.status.AcnetRetryIOError()
+    except acsys.status.AcnetReplyTaskDisconnected as ex:
+        print(f"Captured specific exception: {ex!r}")
+    except acsys.status.AcnetException as ex:
+        print(f"Captured general exception: {ex!r}")
+
+    try:
+        raise acsys.status.Status.create(1+256*-6)
+    except acsys.status.AcnetRequestTimeOutQueuedAtDestination as ex:
+        print(f"Captured specific exception: {ex!r}")
+    except acsys.status.AcnetException as ex:
+        print(f"Captured general exception: {ex!r}")
+
+    l = acsys.status.ACNET_RETRY
+    dex = acsys.status.AcnetNoRequestHandle()
+    try:
+        try:
+            raise acsys.status.AcnetRetryIOError()
+        except acsys.status.AcnetNoRequestHandle as ex:
+            raise
+        except acsys.status.AcnetException as ex:
+            raise acsys.status.AcnetReplyTaskDisconnected() from ex
+        
+    except Exception as ex2:
+        print("Exception captured!")
+        print(f"Captured general exception: {ex2!r}")
+        # raise
+

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -15,3 +15,14 @@ except AcnetRequestTimeOutQueuedAtDestination as ex:
     print(f"Captured specific exception: {ex!r}")
 except AcnetException as ex:
     print(f"Captured general exception: {ex!r}")
+
+
+try:
+    try:
+        raise AcnetRetryIOError()
+    except AcnetException as ex:
+        raise AcnetReplyTaskDisconnected() from ex
+except Exception as ex2:
+    print("Exception captured!")
+    print(f"Captured general exception: {ex2!r}")
+    raise

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -10,3 +10,8 @@ except AcnetReplyTaskDisconnected as ex:
     print(f"Captured exception: {ex!r}")
 except Status as st2:
     print(f"Captured any status: {st2!r}")
+
+try:
+    raise Status.create(1+256*-6)
+except AcnetRequestTimeOutQueuedAtDestination as ex:
+    print(f"Captured exception: {ex!r}")

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,17 +1,17 @@
 from acsys.status import *
 
-st = AcnetRetryIOError()
-print(f"{st!r}")
 
 try:
     print("Raising error")
-    raise st
+    raise AcnetRetryIOError()
 except AcnetReplyTaskDisconnected as ex:
-    print(f"Captured exception: {ex!r}")
-except Status as st2:
-    print(f"Captured any status: {st2!r}")
+    print(f"Captured specific exception: {ex!r}")
+except AcnetException as ex:
+    print(f"Captured general exception: {ex!r}")
 
 try:
     raise Status.create(1+256*-6)
 except AcnetRequestTimeOutQueuedAtDestination as ex:
-    print(f"Captured exception: {ex!r}")
+    print(f"Captured specific exception: {ex!r}")
+except AcnetException as ex:
+    print(f"Captured general exception: {ex!r}")


### PR DESCRIPTION
To address #45 
- Created a sub-class per failing status.
- Created an IntEnum inside status for code values.
- Added a `create(val)` factory method for instantiating a `Status`.
- Fixed `except` clauses and references to old `ACNET_XX` globals.

Some concerns:
- I had to change `ACNET_SUCCESS = 1 + 256 * 0` to `ACNET_SUCCESS = 0` - otherwise I get `ValueError: Invalid ACNET Status code: 0` -> Resolved by validating code `0`.
- When testing I get `ConnectionRefusedError: [Errno 10061] Connect call failed ('131.225.135.139', 6808)` -> Resolved by typing the correct port, addressed in #44 
